### PR TITLE
Cleanup test definitions

### DIFF
--- a/rpm/0001-disable-multilib.patch
+++ b/rpm/0001-disable-multilib.patch
@@ -1,7 +1,7 @@
-From 951a9f2732bd071a0a37c458a16c580a0fff576c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Robin Burchell <robin+git@viroteck.net>
 Date: Thu, 11 Jul 2013 08:51:54 +0000
-Subject: [PATCH 01/10] disable multilib
+Subject: [PATCH] disable multilib
 
 Mer doesn't use it.
 ---
@@ -24,5 +24,5 @@ index 606f70b..da2fd86 100644
  # default library directory can be overriden by defining LIBDIR when
  # running qmake
 -- 
-2.17.1
+2.35.1
 

--- a/rpm/0002-fix-documentation-path.patch
+++ b/rpm/0002-fix-documentation-path.patch
@@ -1,7 +1,7 @@
-From 3ec1fc862a2568a38e30045db0c182eb7ebcf81f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Robin Burchell <robin+git@viroteck.net>
 Date: Thu, 11 Jul 2013 08:53:06 +0000
-Subject: [PATCH 02/10] fix documentation path
+Subject: [PATCH] fix documentation path
 
 ---
  lib/SignOn/doc/doc.pri | 2 +-
@@ -21,5 +21,5 @@ index 46f1148..3f2a96b 100644
      documentation.files += $${folder}
  }
 -- 
-2.17.1
+2.35.1
 

--- a/rpm/0003-Install-tests-add-tests-definition.patch
+++ b/rpm/0003-Install-tests-add-tests-definition.patch
@@ -1,14 +1,15 @@
-From b9eff71cd799f388cc1755f9e5da41a828b3fa92 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Martin Kampas <martin.kampas@tieto.com>
 Date: Mon, 18 Mar 2013 16:50:19 +0100
-Subject: [PATCH 03/10] Install tests, add tests definition
+Subject: [PATCH] Install tests, add tests definition
 
 Signed-off-by: Martin Kampas <martin.kampas@tieto.com>
+Signed-off-by: Raine Makelainen <raine.makelainen@jolla.com>
 ---
- tests/create-tests-definition.pro |  23 +++++
- tests/create-tests-definition.sh  | 145 ++++++++++++++++++++++++++++++
+ tests/create-tests-definition.pro |  23 ++++++
+ tests/create-tests-definition.sh  | 131 ++++++++++++++++++++++++++++++
  tests/tests.pro                   |   2 +
- 3 files changed, 170 insertions(+)
+ 3 files changed, 156 insertions(+)
  create mode 100644 tests/create-tests-definition.pro
  create mode 100755 tests/create-tests-definition.sh
 
@@ -43,10 +44,10 @@ index 0000000..fbaef6e
 +INSTALLS += tests_definition
 diff --git a/tests/create-tests-definition.sh b/tests/create-tests-definition.sh
 new file mode 100755
-index 0000000..bd5550e
+index 0000000..5e40fd0
 --- /dev/null
 +++ b/tests/create-tests-definition.sh
-@@ -0,0 +1,145 @@
+@@ -0,0 +1,131 @@
 +#!/bin/sh
 +
 +test_flag()
@@ -157,36 +158,22 @@ index 0000000..bd5550e
 +    <description>Signon Qt Client Library Tests</description>
 +
 +`generate_test_set libsignon-qt-tests/libsignon-qt-tests \
-+    "SSO API" "Functional" "Component" "single-case,stop-ui"`
-+
-+  </suite>
-+
-+
-+  <suite name="signon-passwordplugin-tests" domain="Accounts and SSO">
++    "signon-qt5-tests" "Functional" "Component" "single-case,stop-ui"`
 +
 +`generate_test_set passwordplugintest/signon-passwordplugin-tests \
-+    "Password" "Functional" "Component"`
-+
-+  </suite>
-+
-+
-+  <suite name="signond" domain="Accounts and SSO">
++    "signon-qt5-tests" "Functional" "Component"`
 +
 +`generate_test_set signond-tests/tst_database \
-+    "SSO CORE" "FIXME" "FIXME" "single-case"`
++    "signon-qt5-tests" "FIXME" "FIXME" "single-case"`
 +
 +`generate_test_set signond-tests/tst_pluginproxy \
-+    "SSO CORE" "FIXME" "FIXME" "single-case"`
++    "signon-qt5-tests" "FIXME" "FIXME" "single-case"`
 +
 +`generate_test_set signond-tests/tst_timeouts \
-+    "SSO CORE" "FIXME" "FIXME" "single-case"`
-+
-+  </suite>
-+
-+  <suite name="signond-extensions" domain="Accounts and SSO">
++    "signon-qt5-tests" "FIXME" "FIXME" "single-case"`
 +
 +`generate_test_set extensions/tst_access_control_manager \
-+    "SSO CORE" "FIXME" "FIXME" "single-case"`
++    "signon-qt5-tests" "FIXME" "FIXME" "single-case"`
 +
 +  </suite>
 +
@@ -206,5 +193,5 @@ index 64c59c1..656391e 100644
      passwordplugintest \
      libsignon-qt-tests \
 -- 
-2.17.1
+2.35.1
 

--- a/rpm/0004-Set-permissions-on-config-dir-correctly.patch
+++ b/rpm/0004-Set-permissions-on-config-dir-correctly.patch
@@ -1,7 +1,7 @@
-From 829a8e057673fb7da1c125ed4e145eb46b2559a4 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Chris Adams <chris.adams@jollamobile.com>
 Date: Thu, 20 Mar 2014 21:44:25 +1000
-Subject: [PATCH 04/10] Set permissions on config dir correctly
+Subject: [PATCH] Set permissions on config dir correctly
 
 Also ensure that signond is launched with privileged permissions
 ---
@@ -61,5 +61,5 @@ index 60ee5e7..f7f83c9 100644
  DBUS_ADAPTORS += \
      ../../lib/signond/com.nokia.SingleSignOn.Backup.xml
 -- 
-2.17.1
+2.35.1
 

--- a/rpm/0005-Guard-PendingCall-against-deletion-by-connected-slot.patch
+++ b/rpm/0005-Guard-PendingCall-against-deletion-by-connected-slot.patch
@@ -1,7 +1,7 @@
-From 4cb23e5f68c2ed7d13ce525ca763db7039605c9d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Chris Adams <chris.adams@jollamobile.com>
 Date: Fri, 6 Feb 2015 15:39:16 +1000
-Subject: [PATCH 05/10] Guard PendingCall against deletion by connected slots
+Subject: [PATCH] Guard PendingCall against deletion by connected slots
 
 This commit uses QPointer to guard the PendingCall object (and the
 QDBusPendingCallWatcher associated with it).
@@ -44,5 +44,5 @@ index 8656e48..94db648 100644
  
  void PendingCall::onInterfaceDestroyed()
 -- 
-2.17.1
+2.35.1
 

--- a/rpm/0006-Always-use-P2P-DBus-if-enabled.-Contributes-to-JB-42.patch
+++ b/rpm/0006-Always-use-P2P-DBus-if-enabled.-Contributes-to-JB-42.patch
@@ -1,7 +1,7 @@
-From 11448b40f19f3b5e0b0a981ea16335d3ec7b3a38 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Chris Adams <chris.adams@jollamobile.com>
 Date: Tue, 19 Jun 2018 15:06:11 +1000
-Subject: [PATCH 06/10] Always use P2P DBus if enabled. Contributes to JB#42126
+Subject: [PATCH] Always use P2P DBus if enabled. Contributes to JB#42126
 
 This commit ensures that if the enable-p2p config is set, we don't
 ever allow falling back to the session bus to service signon requests,
@@ -89,5 +89,5 @@ index 1458c50..472fbe8 100644
  
  headers.files = $$public_headers \
 -- 
-2.17.1
+2.35.1
 

--- a/rpm/0007-Use-p2p-dbus-for-signon-ui-flows.-Contributes-to-JB-.patch
+++ b/rpm/0007-Use-p2p-dbus-for-signon-ui-flows.-Contributes-to-JB-.patch
@@ -2,14 +2,17 @@ From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Chris Adams <chris.adams@jollamobile.com>
 Date: Tue, 19 Jun 2018 13:15:36 +1000
 Subject: [PATCH] Use p2p dbus for signon-ui flows. Contributes to JB#42126
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 Signed-off-by: Tomi Leppänen <tomi.leppanen@jolla.com>
 ---
  src/signond/signonidentity.cpp    | 26 +++++++++++++++++++--
  src/signond/signonidentity.h      |  1 +
- src/signond/signonsessioncore.cpp | 38 +++++++++++++++++++++++++++++--
+ src/signond/signonsessioncore.cpp | 39 +++++++++++++++++++++++++++++--
  src/signond/signonsessioncore.h   |  1 +
- 4 files changed, 62 insertions(+), 4 deletions(-)
+ 4 files changed, 63 insertions(+), 4 deletions(-)
 
 diff --git a/src/signond/signonidentity.cpp b/src/signond/signonidentity.cpp
 index a143c22..1bc3862 100644
@@ -82,7 +85,7 @@ index f6321f3..885cebd 100644
      SignonIdentityInfo *m_pInfo;
      bool m_destroyed;
 diff --git a/src/signond/signonsessioncore.cpp b/src/signond/signonsessioncore.cpp
-index b0510db..0135f12 100644
+index b0510db..9ef4b57 100644
 --- a/src/signond/signonsessioncore.cpp
 +++ b/src/signond/signonsessioncore.cpp
 @@ -34,6 +34,11 @@
@@ -174,5 +177,5 @@ index d4a428c..bb0543b 100644
  
      QDBusPendingCallWatcher *m_watcher;
 -- 
-2.30.2
+2.35.1
 

--- a/rpm/0008-Initialize-secrets-db-on-start.-Fixes-JB-34557.patch
+++ b/rpm/0008-Initialize-secrets-db-on-start.-Fixes-JB-34557.patch
@@ -1,7 +1,7 @@
-From 664c973ec9a7882aa5f0468e029c6bb16910958b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Marko=20Kentt=C3=A4l=C3=A4?= <marko.kenttala@jolla.com>
 Date: Fri, 26 Oct 2018 11:47:24 +0300
-Subject: [PATCH 08/10] Initialize secrets db on start. Fixes JB#34557
+Subject: [PATCH] Initialize secrets db on start. Fixes JB#34557
 
 ---
  libexec/libexec.pro           | 12 ++++++++++
@@ -116,5 +116,5 @@ index 1eda2b9..b377e6b 100644
      m_instance = new SignonDaemon(app);
      return m_instance;
 -- 
-2.17.1
+2.35.1
 

--- a/rpm/0009-Treat-empty-ACL-as-synonym-for-.-Contributes-to-JB-2.patch
+++ b/rpm/0009-Treat-empty-ACL-as-synonym-for-.-Contributes-to-JB-2.patch
@@ -1,8 +1,7 @@
-From 967093ee60da4b046e7b5b9645ff54d330eaa441 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Chris Adams <chris.adams@jollamobile.com>
 Date: Mon, 22 Jul 2019 14:00:51 +1000
-Subject: [PATCH 09/10] Treat empty ACL as synonym for "*". Contributes to
- JB#27876
+Subject: [PATCH] Treat empty ACL as synonym for "*". Contributes to JB#27876
 
 Prior to 03dd20ef043bd5c1035387998c59312ccc704a59 the ACL was
 bypassed if the identity had no owner.
@@ -32,5 +31,5 @@ index 931efc3..40ef357 100644
  
      return peerHasOneOfAccesses(peerConnection, peerMessage, acl);
 -- 
-2.17.1
+2.35.1
 

--- a/rpm/0010-Use-P2P-DBus-server-for-tests-if-built-in-ENABLE_P2P.patch
+++ b/rpm/0010-Use-P2P-DBus-server-for-tests-if-built-in-ENABLE_P2P.patch
@@ -2,6 +2,9 @@ From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Chris Adams <chris.adams@jollamobile.com>
 Date: Wed, 20 May 2020 16:05:15 +1000
 Subject: [PATCH] Use P2P DBus server for tests if built in ENABLE_P2P mode
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
 Also increase timeout of timeouts test, to allow dbus timeout
 to trigger first (required for successful notification of identity
@@ -193,5 +196,5 @@ index dae8e4b..fb00acd 100644
  
  void TimeoutsTest::initTestCase()
 -- 
-2.30.2
+2.35.1
 


### PR DESCRIPTION
Contains two commits:
1) [tests] Cleanup test definitions. Fixes JB#57294
2) Format patches as no-numbered zero-commits

It is good practice to format patches as follows:
> git format-patch --zero-commit -N --no-signoff