### PR TITLE
[libsignon] Increase maximum token storage size. JB#56536

### DIFF
--- a/rpm/0011-Increase-maximum-token-storage-size.patch
+++ b/rpm/0011-Increase-maximum-token-storage-size.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tomi=20Lepp=C3=A4nen?= <tomi.leppanen@jolla.com>
+Date: Fri, 26 Aug 2022 14:56:43 +0300
+Subject: [PATCH] Increase maximum token storage size
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Increase maximum token storage size to 16 kB as not all OAuth tokens
+will fit to 4 kB.
+
+Signed-off-by: Tomi Leppänen <tomi.leppanen@jolla.com>
+---
+ src/signond/credentialsdb.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/signond/credentialsdb.h b/src/signond/credentialsdb.h
+index d903f86..1417702 100644
+--- a/src/signond/credentialsdb.h
++++ b/src/signond/credentialsdb.h
+@@ -36,7 +36,7 @@
+ 
+ #include "SignOn/abstract-secrets-storage.h"
+ 
+-#define SSO_MAX_TOKEN_STORAGE (4*1024) // 4 kB for token store/identity/method
++#define SSO_MAX_TOKEN_STORAGE (16*1024) // 16 kB for token store/identity/method
+ 
+ class TestDatabase;
+ 
+-- 
+2.37.2
+

--- a/rpm/signon-qt5.spec
+++ b/rpm/signon-qt5.spec
@@ -17,6 +17,7 @@ Patch7:  0007-Use-p2p-dbus-for-signon-ui-flows.-Contributes-to-JB-.patch
 Patch8:  0008-Initialize-secrets-db-on-start.-Fixes-JB-34557.patch
 Patch9:  0009-Treat-empty-ACL-as-synonym-for-.-Contributes-to-JB-2.patch
 Patch10: 0010-Use-P2P-DBus-server-for-tests-if-built-in-ENABLE_P2P.patch
+Patch11: 0011-Increase-maximum-token-storage-size.patch
 
 BuildRequires: doxygen
 BuildRequires: pkgconfig(Qt5Core)


### PR DESCRIPTION
Increase maximum token storage size as some tokens don't fit into 4 kB
of storage. New value is 16 kB which should still be well below [sqlite's
maximum](https://www.sqlite.org/limits.html).