### PR TITLE
[signon] Fix signon occasionally hanging. JB#63919

### DIFF
--- a/rpm/0013-Avoid-hanging-if-there-are-multiple-ipc-blobs-waitin.patch
+++ b/rpm/0013-Avoid-hanging-if-there-are-multiple-ipc-blobs-waitin.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pekka Vuorela <pekka.vuorela@jolla.com>
+Date: Thu, 2 Apr 2026 15:08:20 +0300
+Subject: [PATCH] Avoid hanging if there are multiple ipc blobs waiting to be
+ handled
+
+Big messages are split into smaller fractions. Now if by the time
+the BlobIOHandler starts reading one and the next one is already in the
+queue, it keeps on waiting for an activated() signal that never gets
+there.
+
+Thus, if there's more data available at the end, schedule a next
+read attempt.
+---
+ lib/plugins/signon-plugins-common/SignOn/blobiohandler.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/lib/plugins/signon-plugins-common/SignOn/blobiohandler.cpp b/lib/plugins/signon-plugins-common/SignOn/blobiohandler.cpp
+index cb00e53..0f23cf4 100644
+--- a/lib/plugins/signon-plugins-common/SignOn/blobiohandler.cpp
++++ b/lib/plugins/signon-plugins-common/SignOn/blobiohandler.cpp
+@@ -27,6 +27,7 @@
+ #include <QBuffer>
+ #include <QDataStream>
+ #include <QDebug>
++#include <QTimer>
+ 
+ #include "SignOn/signonplugincommon.h"
+ 
+@@ -152,6 +153,9 @@ void BlobIOHandler::readBlob()
+         setReadNotificationEnabled(false);
+ 
+         emit dataReceived(sessionDataMap);
++    } else if (m_readChannel->bytesAvailable() > 0) {
++        // more data available already, schedule a read attempt for the next fraction
++        QTimer::singleShot(0, this, &BlobIOHandler::readBlob);
+     }
+ }
+ 


### PR DESCRIPTION
Big messages are split into smaller fractions. Now if by the time the BlobIOHandler starts reading one and the next one is already in the queue, it keeps on waiting for an activated() signal that never gets there.

Thus, if there's more data available at the end, schedule a next read attempt.

--- 

Hoping this is all but I'll keep on following. The related code is somewhat suspicious. Planning on making an upstream PR too.